### PR TITLE
Adds crate publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           prerelease: false
           generate_release_notes: true
 
-  build-release:
+  build-assets:
     name: Build (${{ matrix.target }})
     needs: create-release
     runs-on: ${{ matrix.os }}
@@ -96,3 +96,17 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ env.ASSET }}
+
+  publish-crate:
+    name: Publish to crates.io
+    needs: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cargo Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish


### PR DESCRIPTION
Adds a new job to the release workflow that publishes the crate to crates.io. This allows for automated publishing upon release creation.

Also renames "build-release" job to "build-assets" to better reflect its purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release workflow now supports multi-platform builds, automatically generating optimized binaries for various operating systems and architectures.
  * Implemented automatic publishing to crates.io as part of the release process, enabling seamless package distribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->