### PR TITLE
Adds support for running daily builds

### DIFF
--- a/src/core/daily.rs
+++ b/src/core/daily.rs
@@ -156,7 +156,7 @@ pub fn find_match(
     Ok(candidates[0].clone())
 }
 
-fn human_sort_version(v1: &str, v2: &str) -> std::cmp::Ordering {
+pub fn human_sort_version(v1: &str, v2: &str) -> std::cmp::Ordering {
     let v1_parts: Vec<&str> = v1.split('.').collect();
     let v2_parts: Vec<&str> = v2.split('.').collect();
 


### PR DESCRIPTION
Extends the `run` command to correctly resolve and execute daily builds when the "daily" version is specified.

It achieves this by:
- Resolving the "daily" alias to the latest installed daily build.
- Sorting installed versions by date to find the newest one.
- Updating the startup message to reflect the resolved version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for "daily" as a version alias, which automatically resolves to the latest installed daily build when specified

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->