### PR TITLE
Extends build matching logic

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,6 @@
+fix:
+    cargo clippy --fix --allow-dirty --allow-staged --all-targets -- -D warnings
+
+fmt:
+    just fix
+    cargo fmt --all


### PR DESCRIPTION
Extends the build matching logic to include the risk ID in the version query, allowing for specific builds to be identified by their version and risk ID (e.g., "4.5.7-candidate"). This change ensures correct identification of builds with risk IDs, such as beta or candidate versions. Adds a unit test to verify the correct matching of builds using the new logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for version aliases in the format "{version}-{risk_id}" (e.g., "4.5.7-candidate", "5.1.0-beta") for version matching.

* **Chores**
  * Added new build script targets for automated code formatting and linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->